### PR TITLE
setup.py for packaging and `pip install`-ability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,266 @@
+# App Specific
+
+### PYTHON
+### from https://raw.githubusercontent.com/github/gitignore/master/Python.gitignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+
+
+### VIRTUALENV
+### from https://raw.githubusercontent.com/github/gitignore/master/Global/VirtualEnv.gitignore
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json
+
+
+
+### MACOS
+### from https://raw.githubusercontent.com/github/gitignore/master/Global/macOS.gitignore
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+
+### WINDOWS
+### from https://raw.githubusercontent.com/github/gitignore/master/Global/Windows.gitignore
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+
+### LINUX
+### from https://raw.githubusercontent.com/github/gitignore/master/Global/Linux.gitignore
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+
+
+### VIM
+### from https://raw.githubusercontent.com/github/gitignore/master/Global/Vim.gitignore
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+
+
+
+### SUBLIMETEXT
+### from https://raw.githubusercontent.com/github/gitignore/master/Global/SublimeText.gitignore
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# Workspace files are user-specific
+*.sublime-workspace
+
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+
+# SFTP configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+
+
+### VAGRANT
+### from https://raw.githubusercontent.com/github/gitignore/master/Global/Vagrant.gitignore
+# General
+.vagrant/
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.logs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include j2lint *.py
+include LICENSE
+include setup.cfg
+include setup.py
+include README.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+SHELL := /bin/bash
+MAKEFILE_RULES := $(shell cat Makefile | grep "^[A-Za-z]" | awk '{print $$1}' | sed "s/://g" | sort -u)
+PYTHON_EXE := python3
+PYTHON_ENV := ./env
+PYTHON_BIN := $(PYTHON_ENV)/bin
+PYTHON_REQUIREMENTS := ./requirements.txt
+
+
+DEFAULT: help
+
+
+#================================================================================
+# Environment
+#================================================================================
+
+.PHONY: requirements.txt
+requirements.txt:  ## Write the requirements.txt file.
+requirements.txt: virtualenv
+	$(PYTHON_BIN)/pip freeze > $(PYTHON_REQUIREMENTS)
+
+
+virtualenv:  ## Build the python virtual environment.
+	@echo -e "Building/verifying virtualenv at $(PYTHON_ENV) based on $(PYTHON_REQUIREMENTS)\n"
+	@command -v pip >/dev/null 2>&1 || { echo >&2 "I require pip but it's not installed.  Aborting."; exit 1; }
+	@if [ ! -f "$(PYTHON_ENV)/bin/activate" ] ; then \
+		 virtualenv -p $(PYTHON_EXE) $(PYTHON_ENV) ; \
+	fi
+	$(PYTHON_BIN)/pip install -q -r $(PYTHON_REQUIREMENTS)
+	$(PYTHON_BIN)/pip install -q flake8
+
+
+#================================================================================
+# Distribution
+#================================================================================
+
+package: dist
+
+dist:  ## Build the Annotator package binaries.
+dist:
+	$(PYTHON_BIN)/$(PYTHON_EXE) setup.py sdist bdist bdist_wheel
+
+
+#================================================================================
+# Cleanliness
+#================================================================================
+
+lint: pylint
+flake8: pylint
+
+.PHONY: lint
+pylint:  ## Lint the Python app.
+pylint: virtualenv
+	$(PYTHON_BIN)/flake8 *.py j2lint/*.py
+
+
+#================================================================================
+# Extras
+#================================================================================
+
+.PHONY: help
+help:  ## This help dialog.
+	@echo -e  "You can run the following commands from this$(MAKEFILE_LIST):\n"
+	@IFS=$$'\n' ; \
+	help_lines=(`fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//'`) ; \
+	for help_line in $${help_lines[@]}; do \
+		IFS=$$'#' ; \
+		help_split=($$help_line) ; \
+		help_command=`echo $${help_split[0]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+		help_info=`echo $${help_split[2]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+		printf "  %-27s %s\n" $$help_command $$help_info ; \
+	done

--- a/j2lint/__init__.py
+++ b/j2lint/__init__.py
@@ -31,6 +31,7 @@ def check(template, out, err, env=jinja2.Environment(loader=AbsolutePathLoader()
         err.write("%s: Syntax check failed: %s in %s at %d\n" % (template, e.message, e.filename, e.lineno))
         return 1
 
+
 def main(**kwargs):
     import sys
     try:
@@ -38,6 +39,6 @@ def main(**kwargs):
     except IndexError:
         sys.stdout.write("Usage: j2lint.py filename [filename ...]\n")
 
+
 if __name__ == "__main__":
     main()
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Jinja2==2.10
+MarkupSafe==1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E501
+
+[pep8]
+ignore = E501

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(
+    name='j2lint',
+    version='1.0',
+    description='jinja2 linter',
+    author='Gerard van Helden',
+    license='DBAD',
+    url='https://github.com/drm/jinja2-lint',
+    entry_points={
+        'console_scripts': [
+            'j2lint=j2lint:main',
+            'jinja2lint=j2lint:main',
+        ]
+    },
+    packages=[
+        'j2lint',
+    ],
+    install_requires=[
+        'jinja2'
+    ],
+)


### PR DESCRIPTION
This will allow `j2lint` and `jinja2lint` to be run directly as cli commands:

```
$ j2lint woot.j2
woot.j2: Syntax OK

$ jinja2lint woot.j2
woot.j2: Syntax OK
```

Included a couple minor `flake8` linting cleanups in the main file. Otherwise, the only major change to your code is the file renaming.

Apologies for the insane `.gitignore` file - pulled it from another project without realizing how out of control it had become 😛  I can ditch that if it's unreasonable.