### PR TITLE
Remove ansible import

### DIFF
--- a/j2lint.py
+++ b/j2lint.py
@@ -8,7 +8,6 @@ Simple j2 linter, useful for checking jinja2 template syntax
 import os.path
 from functools import reduce
 from jinja2 import BaseLoader, TemplateNotFound, Environment, exceptions
-from ansible.plugins.filter.ipaddr import ipaddr
 
 class AbsolutePathLoader(BaseLoader):
     def get_source(self, environment, template):
@@ -21,7 +20,6 @@ class AbsolutePathLoader(BaseLoader):
 
 def check(template, out, err, env=Environment(loader=AbsolutePathLoader(),extensions=['jinja2.ext.i18n','jinja2.ext.do','jinja2.ext.loopcontrols'])):
     try:
-        env.filters['ipaddr'] = ipaddr
         env.get_template(template)
         out.write("%s: Syntax OK\n" % template)
         return 0


### PR DESCRIPTION
Fails on docker, will also fail if you don't install ansible, which
shouldn't be required for running a jinja lint.