### PR TITLE
Python3; argparse; quiet options; custom filters via cli

### DIFF
--- a/j2lint.py
+++ b/j2lint.py
@@ -11,6 +11,7 @@ import sys
 from functools import reduce
 from jinja2 import BaseLoader, TemplateNotFound, Environment, exceptions
 
+
 class AbsolutePathLoader(BaseLoader):
     def get_source(self, environment, template):
         if not os.path.exists(template):
@@ -20,7 +21,9 @@ class AbsolutePathLoader(BaseLoader):
             source = file.read()
         return source, template, lambda: mtime == os.path.getmtime(template)
 
-def check(template, out, err, env=Environment(loader=AbsolutePathLoader(),extensions=['jinja2.ext.i18n','jinja2.ext.do','jinja2.ext.loopcontrols'])):
+env=Environment(loader=AbsolutePathLoader(),extensions=['jinja2.ext.i18n','jinja2.ext.do','jinja2.ext.loopcontrols'])
+
+def check(template, out, err, ):
     try:
         env.get_template(template)
         if not args.quiet:
@@ -38,8 +41,11 @@ def main(**kwargs):
     global args
     parser = argparse.ArgumentParser(description='Lint jinja2 files')
     parser.add_argument('--quiet', action='store_true',help='Only print errors')
+    parser.add_argument('--filter', metavar='filter',type=str, nargs='+',help='Add custom jinja filter')
     parser.add_argument('files', metavar='file', type=str, nargs='+',help='the files to lint')
     args = parser.parse_args()
+    if args.filter:
+        env.filters.update({name: lambda: None for name in args.filter})
     try:
         status_code = reduce(lambda r, fn: r +
                         check(fn, sys.stdout, sys.stderr, **kwargs), args.files, 0)

--- a/j2lint.py
+++ b/j2lint.py
@@ -6,6 +6,8 @@
 Simple j2 linter, useful for checking jinja2 template syntax
 """
 import os.path
+import argparse
+import sys
 from functools import reduce
 from jinja2 import BaseLoader, TemplateNotFound, Environment, exceptions
 
@@ -21,7 +23,8 @@ class AbsolutePathLoader(BaseLoader):
 def check(template, out, err, env=Environment(loader=AbsolutePathLoader(),extensions=['jinja2.ext.i18n','jinja2.ext.do','jinja2.ext.loopcontrols'])):
     try:
         env.get_template(template)
-        out.write("%s: Syntax OK\n" % template)
+        if not args.quiet:
+            out.write("%s: Syntax OK\n" % template)
         return 0
     except TemplateNotFound:
         err.write("%s: File not found\n" % template)
@@ -32,10 +35,14 @@ def check(template, out, err, env=Environment(loader=AbsolutePathLoader(),extens
         return 1
 
 def main(**kwargs):
-    import sys
+    global args
+    parser = argparse.ArgumentParser(description='Lint jinja2 files')
+    parser.add_argument('--quiet', action='store_true',help='Only print errors')
+    parser.add_argument('files', metavar='file', type=str, nargs='+',help='the files to lint')
+    args = parser.parse_args()
     try:
         status_code = reduce(lambda r, fn: r +
-                        check(fn, sys.stdout, sys.stderr, **kwargs), sys.argv[1:], 0)
+                        check(fn, sys.stdout, sys.stderr, **kwargs), args.files, 0)
         sys.exit(status_code)
     except IndexError:
         print("Usage: j2lint.py filename [filename ...]\n")

--- a/j2lint.py
+++ b/j2lint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 @author Gerard van Helden <drm@melp.nl>
 @license DBAD, see <http://www.dbad-license.org/>
@@ -34,10 +34,11 @@ def check(template, out, err, env=Environment(loader=AbsolutePathLoader(),extens
 def main(**kwargs):
     import sys
     try:
-        sys.exit(reduce(lambda r, fn: r +
-                        check(fn, sys.stdout, sys.stderr, **kwargs), sys.argv[1:], 0))
+        status_code = reduce(lambda r, fn: r +
+                        check(fn, sys.stdout, sys.stderr, **kwargs), sys.argv[1:], 0)
+        sys.exit(status_code)
     except IndexError:
-        sys.stdout.write("Usage: j2lint.py filename [filename ...]\n")
+        print("Usage: j2lint.py filename [filename ...]\n")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR introduces:

* Python3 support on current debian hosts
* The --quiet option to only report errors
* The --filter Filter option to add custom jinja filters
* Use of pythons modul argparse.