### PR TITLE
fix: "ImportError: No module named ansible.plugins.filter.ipaddr"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:latest
 
 USER root
-RUN apk add --no-cache ansible py3-ipaddr coreutils findutils && \
+RUN apk add --no-cache ansible py3-pip coreutils findutils && \
+    pip3 install --no-cache-dir ipaddr jinja2-ansible-filters && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     mkdir -p /check
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:latest
 
 USER root
-RUN apk add --no-cache ansible py3-ipaddr
-RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN mkdir -p /check
+RUN apk add --no-cache ansible py3-ipaddr coreutils findutils && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    mkdir -p /check
 
 COPY j2lint.py /
 COPY init.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM alpine:latest
 
 USER root
-RUN apk add --no-cache ansible py3-pip coreutils findutils && \
-    pip3 install --no-cache-dir ipaddr jinja2-ansible-filters && \
+RUN apk add --no-cache coreutils findutils && \
+    apk add --no-cache py3-pip py3-cffi py3-cryptography py3-ipaddr py3-ipaddress py3-jinja2 py3-markupsafe py3-netaddr py3-yaml && \
+    pip3 install --no-cache-dir "ansible>=2.10,<2.11" jinja2-ansible-filters && \
+    apk del --no-cache py3-pip && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     mkdir -p /check
 
@@ -10,6 +12,5 @@ COPY j2lint.py /
 COPY init.sh /
 ENV CUSTOMLINT=customj2lint.py
 
-USER nobody
 
 CMD ["/usr/bin/env", "sh", "/init.sh"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you want to use this linter with custom filters, tests, etc, you can easily
 extend the main cli endpoint by passing in a `env` keyword argument.
 
 The file [custom_check_example.py](custom_check_example.py) provides a working example for the filter
-'to_nice_json'. 
+'to_nice_json'.
 
 Note that for linting it is not necessary to refer to the actual implementation
 of the filters, jinja2 only needs to know they exist.
@@ -39,3 +39,22 @@ Important options:
 * `-e CUSTOMLINT=path/to/custom/lint`: the path to a custom lint py file in the directory you're checking.
   By default we check for `/custom.py`, so you can mount a file there instead of specifying this.
 * `-v "$(pwd)":/check`: mount the current directory to `/check` on the container
+
+## Usage with gitlab-ci
+
+```
+stages:
+  - lint
+
+jinja2-lint:
+  image:
+    name: tuxmartin/jinja2-lint:2022-05-24
+    entrypoint: ["/bin/sh", "-c"]
+  stage: lint
+  script:
+    - pwd
+    - ls -lha templates/
+    - >
+      find templates/* \( -name '*' ! -iname ".*" \)
+      -print0 | sort --zero-terminated | xargs -0 -I{} sh -c  '/usr/bin/python /j2lint.py {}'
+```

--- a/j2lint.py
+++ b/j2lint.py
@@ -7,9 +7,11 @@ Simple j2 linter, useful for checking jinja2 template syntax
 """
 import os.path
 from functools import reduce
-from jinja2 import BaseLoader, TemplateNotFound, Environment, exceptions
+from jinja2 import BaseLoader, TemplateNotFound, Environment, exceptions, filters
 from jinja2_ansible_filters import AnsibleCoreFiltersExtension
+from ansible_collections.ansible.netcommon.plugins.filter import ipaddr
 
+filters.FILTERS['ipaddr'] = ipaddr
 class AbsolutePathLoader(BaseLoader):
     def get_source(self, environment, template):
         if not os.path.exists(template):
@@ -24,7 +26,8 @@ def check(template, out, err,
     'jinja2.ext.i18n',
     'jinja2.ext.do',
     'jinja2.ext.loopcontrols',
-    'jinja2_ansible_filters.AnsibleCoreFiltersExtension']
+    'jinja2_ansible_filters.AnsibleCoreFiltersExtension'
+    ]
   )):
     try:
         env.get_template(template)

--- a/j2lint.py
+++ b/j2lint.py
@@ -8,6 +8,7 @@ Simple j2 linter, useful for checking jinja2 template syntax
 import os.path
 from functools import reduce
 from jinja2 import BaseLoader, TemplateNotFound, Environment, exceptions
+from jinja2_ansible_filters import AnsibleCoreFiltersExtension
 
 class AbsolutePathLoader(BaseLoader):
     def get_source(self, environment, template):
@@ -18,7 +19,13 @@ class AbsolutePathLoader(BaseLoader):
             source = file.read()
         return source, template, lambda: mtime == os.path.getmtime(template)
 
-def check(template, out, err, env=Environment(loader=AbsolutePathLoader(),extensions=['jinja2.ext.i18n','jinja2.ext.do','jinja2.ext.loopcontrols'])):
+def check(template, out, err,
+  env=Environment(loader=AbsolutePathLoader(),extensions=[
+    'jinja2.ext.i18n',
+    'jinja2.ext.do',
+    'jinja2.ext.loopcontrols',
+    'jinja2_ansible_filters.AnsibleCoreFiltersExtension']
+  )):
     try:
         env.get_template(template)
         out.write("%s: Syntax OK\n" % template)

--- a/jinja2-lint.Dockerfile
+++ b/jinja2-lint.Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 USER root
-RUN apk add --no-cache ansible
+RUN apk add --no-cache ansible py3-ipaddr
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /check
 
@@ -12,4 +12,3 @@ ENV CUSTOMLINT=customj2lint.py
 USER nobody
 
 CMD ["/usr/bin/env", "sh", "/init.sh"]
-


### PR DESCRIPTION
```
$ docker run --rm -v "$(pwd)":/check kaictl/j2lint
Traceback (most recent call last):
  File "/j2lint.py", line 11, in <module>
    from ansible.plugins.filter.ipaddr import ipaddr
ImportError: No module named ansible.plugins.filter.ipaddr
```