### PR TITLE
Update ipaddr import

### DIFF
--- a/j2lint.py
+++ b/j2lint.py
@@ -9,7 +9,11 @@ import os.path
 from functools import reduce
 from jinja2 import BaseLoader, TemplateNotFound, Environment, exceptions, filters
 from jinja2_ansible_filters import AnsibleCoreFiltersExtension
-from ansible_collections.ansible.utils.plugins.filter import ipaddr
+try:
+  from ansible_collections.ansible.utils.plugins.filter import ipaddr
+except:
+  from ansible_collections.ansible.netcommon.plugins.filter import ipaddr
+
 
 filters.FILTERS['ipaddr'] = ipaddr
 class AbsolutePathLoader(BaseLoader):

--- a/j2lint.py
+++ b/j2lint.py
@@ -9,7 +9,7 @@ import os.path
 from functools import reduce
 from jinja2 import BaseLoader, TemplateNotFound, Environment, exceptions, filters
 from jinja2_ansible_filters import AnsibleCoreFiltersExtension
-from ansible_collections.ansible.netcommon.plugins.filter import ipaddr
+from ansible_collections.ansible.utils.plugins.filter import ipaddr
 
 filters.FILTERS['ipaddr'] = ipaddr
 class AbsolutePathLoader(BaseLoader):


### PR DESCRIPTION
Since Ansible 2.13, ipaddr has been moved to the ansible.utils collection.